### PR TITLE
Fix manifest for webRequestBlocking

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,18 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Third Party Cookie Blocker",
   "description": "Blockiert Drittanbieter-Cookies standardmäßig mit Whitelist-Funktion",
   "version": "1.0",
-  "permissions": ["storage", "webRequest", "webRequestBlocking", "tabs"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "storage",
+    "webRequest",
+    "webRequestBlocking",
+    "tabs",
+    "<all_urls>"
+  ],
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"],
+    "persistent": false
   },
   "action": {
     "default_title": "Cookie Blocker",


### PR DESCRIPTION
## Summary
- downgrade to manifest version 2 to allow webRequestBlocking
- use background script instead of service worker
- include `<all_urls>` permission directly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68869b3e95f08328828470692d60859a